### PR TITLE
Publish linux/arm64 Docker image

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,7 @@
 name: Build and publish Docker image
 
 env:
-  platforms: linux/amd64
+  platforms: linux/amd64,linux/arm64
 
 on:
   push:


### PR DESCRIPTION
This is needed for https://github.com/ironcore-dev/metal-operator/pull/120 to run boot-operator in `kind` cluster on Mac with ARM chip.