### PR TITLE
Add support for UUID-specific iPXE scripts via /ipxe/<uuid>

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,6 @@ func init() {
 
 func main() {
 	ctx := ctrl.LoggerInto(ctrl.SetupSignalHandler(), setupLog)
-	defaultIpxeTemplateData := NewDefaultIPXETemplateData()
 	defaultHttpUKIURL := NewDefaultHTTPBootData()
 	skipControllerNameValidation := true
 
@@ -254,7 +253,7 @@ func main() {
 	}
 
 	setupLog.Info("starting boot-server")
-	go bootserver.RunBootServer(bootserverAddr, ipxeServiceURL, mgr.GetClient(), serverLog.WithName("bootserver"), *defaultIpxeTemplateData, *defaultHttpUKIURL)
+	go bootserver.RunBootServer(bootserverAddr, ipxeServiceURL, mgr.GetClient(), serverLog.WithName("bootserver"), *defaultHttpUKIURL)
 
 	setupLog.Info("starting image-proxy-server")
 	go bootserver.RunImageProxyServer(imageProxyServerAddr, mgr.GetClient(), serverLog.WithName("imageproxyserver"))
@@ -311,16 +310,6 @@ func IndexHTTPBootConfigBySystemIPs(ctx context.Context, mgr ctrl.Manager) error
 			return HTTPBootConfig.Spec.SystemIPs
 		},
 	)
-}
-
-func NewDefaultIPXETemplateData() *bootserver.IPXETemplateData {
-	var cfg bootserver.IPXETemplateData
-	flag.StringVar(&cfg.KernelURL, "default-kernel-url", "", "Default URL for the kernel")
-	flag.StringVar(&cfg.InitrdURL, "default-initrd-url", "", "Default URL for the initrd")
-	flag.StringVar(&cfg.SquashfsURL, "default-squashfs-url", "", "Default URL for the squashfs")
-	flag.StringVar(&cfg.IPXEServerURL, "default-ipxe-server-url", "", "Default IPXE Server URL to while generating ipxe-script")
-
-	return &cfg
 }
 
 func NewDefaultHTTPBootData() *string {

--- a/server/bootserver.go
+++ b/server/bootserver.go
@@ -97,7 +97,7 @@ func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client,
 	}
 
 	if len(ipxeBootConfigList.Items) == 0 {
-		log.Info("No specified UUID is found, delivering default script")
+		log.Info("No IPXEBootConfig found for the given UUID")
 		http.Error(w, "Resource Not Found", http.StatusNotFound)
 		return
 	}

--- a/server/bootserver.go
+++ b/server/bootserver.go
@@ -38,6 +38,10 @@ func RunBootServer(ipxeServerAddr string, ipxeServiceURL string, k8sClient clien
 		handleIPXE(w, r, k8sClient, log, ipxeServiceURL, defaultIpxeTemplateData)
 	})
 
+	http.HandleFunc("/ipxe/", func(w http.ResponseWriter, r *http.Request) {
+		handleIPXE(w, r, k8sClient, log, ipxeServiceURL, defaultIpxeTemplateData)
+	})
+
 	http.HandleFunc("/httpboot", func(w http.ResponseWriter, r *http.Request) {
 		handleHTTPBoot(w, r, k8sClient, log, defaultUKIURL)
 	})
@@ -83,41 +87,27 @@ func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client,
 	log.Info("Processing IPXE request", "method", r.Method, "path", r.URL.Path, "clientIP", r.RemoteAddr)
 	ctx := r.Context()
 
-	clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		log.Error(err, "Failed to parse client IP address", "clientIP", r.RemoteAddr)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	clientIPs := []string{clientIP}
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		for _, ip := range strings.Split(xff, ",") {
-			trimmedIP := strings.TrimSpace(ip)
-			if trimmedIP != "" {
-				clientIPs = append(clientIPs, trimmedIP)
-			}
-		}
-	}
-
-	var ipxeConfigs bootv1alpha1.IPXEBootConfigList
-	for _, ip := range clientIPs {
-		if err := k8sClient.List(ctx, &ipxeConfigs, client.MatchingFields{bootv1alpha1.SystemIPIndexKey: ip}); err != nil {
-			log.Info("Failed to list IPXEBootConfig for IP", "IP", ip, "error", err)
-			continue
+	if strings.HasPrefix(r.URL.Path, "/ipxe/") {
+		uuid := strings.TrimPrefix(r.URL.Path, "/ipxe/")
+		if uuid == "" {
+			http.Error(w, "Bad Request: UUID is required", http.StatusBadRequest)
+			return
 		}
 
-		if len(ipxeConfigs.Items) > 0 {
-			log.Info("Found IPXEBootConfig", "IP", ip)
-			break
+		ipxeBootConfigList := &bootv1alpha1.IPXEBootConfigList{}
+		err := k8sClient.List(ctx, ipxeBootConfigList, client.MatchingFields{bootv1alpha1.SystemUUIDIndexKey: uuid})
+		if client.IgnoreNotFound(err) != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
 		}
-	}
 
-	if len(ipxeConfigs.Items) == 0 {
-		log.Info("No IPXEBootConfig found for client IP, delivering default script", "clientIP", clientIP)
-		serveDefaultIPXETemplate(w, log, defaultIpxeTemplateData)
-	} else {
-		config := ipxeConfigs.Items[0]
+		if len(ipxeBootConfigList.Items) == 0 {
+			log.Info("No specified UUID is found, delivering default script")
+			serveDefaultIPXETemplate(w, log, defaultIpxeTemplateData)
+			return
+		}
+
+		config := ipxeBootConfigList.Items[0]
 		if config.Spec.IPXEScriptSecretRef != nil {
 			secret := &corev1.Secret{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: config.Spec.IPXEScriptSecretRef.Name, Namespace: config.Namespace}, secret)
@@ -147,7 +137,11 @@ func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client,
 			SquashfsURL:   config.Spec.SquashfsURL,
 			IPXEServerURL: ipxeServiceURL,
 		})
+		return
 	}
+
+	log.Info("No UUID is specified, delivering default script")
+	serveDefaultIPXETemplate(w, log, defaultIpxeTemplateData)
 }
 
 func handleIgnitionIPXEBoot(w http.ResponseWriter, r *http.Request, k8sClient client.Client, log logr.Logger, uuid string) {

--- a/server/bootserver.go
+++ b/server/bootserver.go
@@ -33,9 +33,9 @@ type IPXETemplateData struct {
 	IPXEServerURL string
 }
 
-func RunBootServer(ipxeServerAddr string, ipxeServiceURL string, k8sClient client.Client, log logr.Logger, defaultIpxeTemplateData IPXETemplateData, defaultUKIURL string) {
+func RunBootServer(ipxeServerAddr string, ipxeServiceURL string, k8sClient client.Client, log logr.Logger, defaultUKIURL string) {
 	http.HandleFunc("/ipxe/", func(w http.ResponseWriter, r *http.Request) {
-		handleIPXE(w, r, k8sClient, log, ipxeServiceURL, defaultIpxeTemplateData)
+		handleIPXE(w, r, k8sClient, log, ipxeServiceURL)
 	})
 
 	http.HandleFunc("/httpboot", func(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +79,7 @@ func RunBootServer(ipxeServerAddr string, ipxeServiceURL string, k8sClient clien
 	}
 }
 
-func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client, log logr.Logger, ipxeServiceURL string, defaultIpxeTemplateData IPXETemplateData) {
+func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client, log logr.Logger, ipxeServiceURL string) {
 	log.Info("Processing IPXE request", "method", r.Method, "path", r.URL.Path, "clientIP", r.RemoteAddr)
 	ctx := r.Context()
 


### PR DESCRIPTION
# Proposed Changes

- return specific ipxe script if `/ipxe/<uuid>` is called and matching ipxeBootConfigList is found
- remove default ipxe script and related params

Fixes https://github.com/ironcore-dev/boot-operator/issues/159