### PR TITLE
Bump Go Version to 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.1
+        version: v2.5

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.dylib
 bin/*
 Dockerfile.cross
+.DS_Store
+go.work*
 
 # Test binary, built with `go test -c`
 *.test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/boot-operator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/containerd/containerd v1.7.29


### PR DESCRIPTION
# Proposed Changes
Needed to align with the latest golangci-lint. 

Fixes #
