### PR TITLE
Fix issue retrieving system uuid from boot config

### DIFF
--- a/internal/controller/serverbootconfiguration_pxe_controller.go
+++ b/internal/controller/serverbootconfiguration_pxe_controller.go
@@ -197,7 +197,7 @@ func (r *ServerBootConfigurationPXEReconciler) getSystemUUIDFromBootConfig(ctx c
 		return "", fmt.Errorf("failed to get Server: %w", err)
 	}
 
-	return server.Spec.UUID, nil
+	return server.Spec.SystemUUID, nil
 }
 
 func (r *ServerBootConfigurationPXEReconciler) getSystemIPFromBootConfig(ctx context.Context, config *metalv1alpha1.ServerBootConfiguration) ([]string, error) {

--- a/internal/controller/serverbootconfiguration_pxe_controller_test.go
+++ b/internal/controller/serverbootconfiguration_pxe_controller_test.go
@@ -38,7 +38,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 				GenerateName: "server-",
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				UUID: "12345",
+				SystemUUID: "12345",
 			},
 		}
 		Expect(k8sClient.Create(ctx, server)).To(Succeed())
@@ -86,7 +86,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 				Controller:         ptr.To(true),
 				BlockOwnerDeletion: ptr.To(true),
 			})),
-			HaveField("Spec.SystemUUID", server.Spec.UUID),
+			HaveField("Spec.SystemUUID", server.Spec.SystemUUID),
 			HaveField("Spec.SystemIPs", ContainElement("1.1.1.1")),
 			HaveField("Spec.IgnitionSecretRef.Name", "foo"),
 		))
@@ -99,7 +99,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 				GenerateName: "server-",
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				UUID: "12345",
+				SystemUUID: "12345",
 			},
 		}
 		Expect(k8sClient.Create(ctx, server)).To(Succeed())
@@ -147,7 +147,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 				Controller:         ptr.To(true),
 				BlockOwnerDeletion: ptr.To(true),
 			})),
-			HaveField("Spec.SystemUUID", server.Spec.UUID),
+			HaveField("Spec.SystemUUID", server.Spec.SystemUUID),
 			HaveField("Spec.SystemIPs", ContainElement("1.1.1.1")),
 			HaveField("Spec.IgnitionSecretRef.Name", "foo"),
 		))


### PR DESCRIPTION
metal operator changed uuid to system uuid, function was missed during that change https://github.com/ironcore-dev/metal-operator/pull/561/files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected server boot configuration to use the proper system UUID identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->