### PR TITLE
Use `nic.IPs` instead of deprecated `nic.IP` in Server API

### DIFF
--- a/internal/controller/serverbootconfiguration_http_controller.go
+++ b/internal/controller/serverbootconfiguration_http_controller.go
@@ -174,7 +174,13 @@ func (r *ServerBootConfigurationHTTPReconciler) getSystemNetworkIDsFromServer(ct
 	nIDs := make([]string, 0, 2*len(server.Status.NetworkInterfaces))
 
 	for _, nic := range server.Status.NetworkInterfaces {
-		nIDs = append(nIDs, nic.IP.String())
+		if len(nic.IPs) > 0 {
+			for _, ip := range nic.IPs {
+				nIDs = append(nIDs, ip.String())
+			}
+		} else if nic.IP != nil && !nic.IP.IsZero() {
+			nIDs = append(nIDs, nic.IP.String())
+		}
 		nIDs = append(nIDs, nic.MACAddress)
 	}
 	return nIDs, nil

--- a/internal/controller/serverbootconfiguration_http_controller_test.go
+++ b/internal/controller/serverbootconfiguration_http_controller_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{
 				{
 					Name:       "foo",
-					IP:         ptr.To(metalv1alpha1.MustParseIP("1.1.1.1")),
+					IPs:        []metalv1alpha1.IP{metalv1alpha1.MustParseIP("1.1.1.1")},
 					MACAddress: "abcd",
 				},
 			}

--- a/internal/controller/serverbootconfiguration_pxe_controller.go
+++ b/internal/controller/serverbootconfiguration_pxe_controller.go
@@ -202,7 +202,15 @@ func (r *ServerBootConfigurationPXEReconciler) getSystemIPFromBootConfig(ctx con
 
 	systemIPs := make([]string, 0, len(server.Status.NetworkInterfaces))
 	for _, nic := range server.Status.NetworkInterfaces {
-		systemIPs = append(systemIPs, nic.IP.String())
+		if len(nic.IPs) > 0 {
+			for _, ip := range nic.IPs {
+				systemIPs = append(systemIPs, ip.String())
+			}
+			continue
+		}
+		if nic.IP != nil && !nic.IP.IsZero() {
+			systemIPs = append(systemIPs, nic.IP.String())
+		}
 	}
 
 	return systemIPs, nil

--- a/internal/controller/serverbootconfiguration_pxe_controller_test.go
+++ b/internal/controller/serverbootconfiguration_pxe_controller_test.go
@@ -48,7 +48,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{
 				{
 					Name:       "foo",
-					IP:         ptr.To(metalv1alpha1.MustParseIP("1.1.1.1")),
+					IPs:        []metalv1alpha1.IP{metalv1alpha1.MustParseIP("1.1.1.1")},
 					MACAddress: "abcd",
 				},
 			}
@@ -109,7 +109,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{
 				{
 					Name:       "foo",
-					IP:         ptr.To(metalv1alpha1.MustParseIP("1.1.1.1")),
+					IPs:        []metalv1alpha1.IP{metalv1alpha1.MustParseIP("1.1.1.1")},
 					MACAddress: "abcd",
 				},
 			}


### PR DESCRIPTION
# Proposed Changes

-
-
-

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple IP addresses per network interface — the system now collects and uses all assigned IPs for each NIC instead of a single IP.

* **Tests**
  * Updated test coverage and test data to reflect the multi‑IP network interface structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->