### PR TITLE
Chart: move `crds` chart logic after setting image

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -55,10 +55,6 @@ jobs:
           fi
           echo "version=$CHART_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Package Helm chart with crds folder in template
-        run: |
-          helm package dist/chart --version ${{ steps.chart_version.outputs.version }}-crds
-
       - name: Install Kustomize
         run: |
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
@@ -73,6 +69,10 @@ jobs:
           IMAGE_TAG=sha-$(echo ${{ github.sha }} | cut -c1-7)
           yq -i '.controllerManager.manager.image.repository = "ghcr.io/ironcore-dev/boot-operator"' dist/chart/values.yaml
           yq -i '.controllerManager.manager.image.tag = "'$IMAGE_TAG'"' dist/chart/values.yaml
+
+      - name: Package Helm chart with crds folder in template
+        run: |
+          helm package dist/chart --version ${{ steps.chart_version.outputs.version }}-crds
 
       - name: Prepare CRDs folder
         run: |


### PR DESCRIPTION
# Proposed Changes

- This makes sure that `crds` chart also has the updated image values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart packaging workflow to generate multiple chart variants—one with CRDs included in the template and another with CRDs removed from the template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->