### PR TITLE
Remove client IP from HTTP boot logic

### DIFF
--- a/server/bootserver.go
+++ b/server/bootserver.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -375,14 +374,7 @@ func handleHTTPBoot(w http.ResponseWriter, r *http.Request, k8sClient client.Cli
 	log.Info("Processing HTTPBoot request", "method", r.Method, "path", r.URL.Path, "clientIP", r.RemoteAddr)
 	ctx := r.Context()
 
-	clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		log.Error(err, "Failed to parse client IP address", "clientIP", r.RemoteAddr)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	clientIPs := []string{clientIP}
+	var clientIPs []string
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		for _, ip := range strings.Split(xff, ",") {
 			trimmedIP := strings.TrimSpace(ip)

--- a/server/bootserver_test.go
+++ b/server/bootserver_test.go
@@ -41,7 +41,7 @@ var _ = Describe("BootServer", func() {
 			Expect(body.UKIURL).To(Equal(defaultUKIURL))
 
 			By("including the recorded client IPs")
-			Expect(body.ClientIPs).NotTo(BeEmpty())
+			Expect(body.ClientIPs).To(BeEmpty())
 
 			By("not setting a SystemUUID in the default case")
 			Expect(body.SystemUUID).To(SatisfyAny(BeEmpty(), Equal("")))


### PR DESCRIPTION
Putting the client IP first in the list of client identifiers to check for boot configuration has the problem that the client is usually FeDHCP. If it uses an IP address of a management server for which a boot configuration exists only that boot configuration will be served for every single boot request.

Adjust the logic to ignore the clients IP address to rely exclusively on the X-Forwarded-For header to resolving the boot configuration.

Resolves: #290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated client IP detection logic; client IP information may not be available in certain network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->