### PR TITLE
 Skip iPXE service URL validation when iPXE controllers are disabled 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -136,14 +136,15 @@ func main() {
 	}
 
 	// set the correct ipxe service URL by getting the address from the environment
-	var ipxeServiceAddr string
-	if ipxeServiceURL == "" {
-		ipxeServiceAddr = os.Getenv("IPXE_SERVER_ADDRESS")
-		if ipxeServiceAddr == "" {
-			setupLog.Error(nil, "failed to set the ipxe service URL as no address is provided")
-			os.Exit(1)
+	if controllers.Enabled(ipxeBootConfigController) || controllers.Enabled(serverBootConfigControllerPxe) {
+		if ipxeServiceURL == "" {
+			ipxeServiceAddr := os.Getenv("IPXE_SERVER_ADDRESS")
+			if ipxeServiceAddr == "" {
+				setupLog.Error(nil, "failed to set the ipxe service URL as no address is provided")
+				os.Exit(1)
+			}
+			ipxeServiceURL = fmt.Sprintf("%s://%s:%d", ipxeServiceProtocol, ipxeServiceAddr, ipxeServicePort)
 		}
-		ipxeServiceURL = fmt.Sprintf("%s://%s:%d", ipxeServiceProtocol, ipxeServiceAddr, ipxeServicePort)
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled

--- a/server/bootserver.go
+++ b/server/bootserver.go
@@ -109,6 +109,10 @@ func RunBootServer(
 
 func handleIPXE(w http.ResponseWriter, r *http.Request, k8sClient client.Client, log logr.Logger, ipxeServiceURL string) {
 	log.Info("Processing IPXE request", "method", r.Method, "path", r.URL.Path, "clientIP", r.RemoteAddr)
+	if ipxeServiceURL == "" {
+		http.Error(w, "iPXE is disabled", http.StatusServiceUnavailable)
+		return
+	}
 	ctx := r.Context()
 
 	uuid := strings.TrimPrefix(r.URL.Path, "/ipxe/")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed IPXE service URL initialization to run only when the related controllers are enabled, instead of attempting initialization whenever the service URL flag is unset.
* **Bug Fixes**
  * iPXE endpoint now returns a 503 response with “iPXE is disabled” when the iPXE service is not configured, avoiding unexpected processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->