### PR TITLE
Improve chart versioning

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -8,16 +8,16 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
     types: [labeled, opened, synchronize, reopened]
 
 jobs:
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v5
@@ -43,15 +45,28 @@ jobs:
       - name: Determine chart version
         id: chart_version
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Use SHA for main branch
-            CHART_VERSION="0.0.0-$(echo ${{ github.sha }} | cut -c1-7)"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             # Use tag version (strip 'v' prefix)
             CHART_VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            # Use PR SHA for dry run
-            CHART_VERSION="0.0.0-$(echo ${{ github.sha }} | cut -c1-7)"
+            # Get the latest tag
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v0.0.0")
+            # Strip 'v' prefix
+            VERSION="${LATEST_TAG#v}"
+            # Remove prerelease/build metadata (everything after '-' or '+')
+            BASE_VERSION="${VERSION%%-*}"
+            BASE_VERSION="${BASE_VERSION%%+*}"
+            # Parse base version
+            MAJOR=$(echo $BASE_VERSION | cut -d. -f1)
+            MINOR=$(echo $BASE_VERSION | cut -d. -f2)
+            PATCH=$(echo $BASE_VERSION | cut -d. -f3)
+            # Increment patch version
+            NEXT_PATCH=$((PATCH + 1))
+            # Get timestamp and short SHA
+            TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+            # Format: major.minor.patch+1-timestamp-sha
+            CHART_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-${TIMESTAMP}-${SHORT_SHA}"
           fi
           echo "version=$CHART_VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes #262



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated publish workflow so chart versions are now derived from the latest tag, automatically bump the patch, and include a UTC timestamp plus commit identifier for clearer, unique releases.
  * Cleaned up CI workflow configuration/formatting for more reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->