### PR TITLE
Remove `paths-ignore` filters from required workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    paths-ignore:
-    - 'docs/**'
-    - '**/*.md'
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,13 +12,7 @@ on:
       - main
     tags:
       - v*
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   test:


### PR DESCRIPTION
# Proposed Changes

- Remove path filters from required workflows. The filters prevent PRs from
  merging if they do not match the filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflows now run for pull requests that modify documentation or Markdown files.
  * Linting, testing, and Docker publishing checks consistently trigger across all pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->